### PR TITLE
[4] Adds version.py to /usr/local/bin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `version.py` added to `/usr/local/bin` to allow task to successfully run in AWS Batch
+
 ## [v0.2.0] - 2021-03-17
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN \
 ADD . ${HOME}
 
 # Add task to $PATH so AWS Batch can run
-COPY task.py /usr/local/bin
+COPY [ "task.py", "version.py", "/usr/local/bin" ]


### PR DESCRIPTION
task.py references version.py and since we typically are using cirrus - if you try to execute this template from batch without specifying the path for task.py will bomb out, because version.py is not also copied to PATH. This change adds version.py to the Dockerfile path.